### PR TITLE
feat: ✨ allow express app to be passed in from the outside

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -35,9 +35,9 @@ export class Server {
   private readonly loggerInstance
 
   constructor (
-    private readonly application: Application,
     private readonly options: RoutingOptions = {},
-    private readonly httpOptions: IHTTPOptions = {}
+    private readonly httpOptions: IHTTPOptions = {},
+    private readonly application?: Application
   ) {
     this.logger = httpOptions.logger ?? defaultLogger
     this.loggerInstance = this.logger('zhttp')

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -35,6 +35,7 @@ export class Server {
   private readonly loggerInstance
 
   constructor (
+    private readonly application: Application,
     private readonly options: RoutingOptions = {},
     private readonly httpOptions: IHTTPOptions = {}
   ) {
@@ -49,7 +50,7 @@ export class Server {
       ...this.httpOptions
     }
 
-    this.app = express()
+    this.app = application ?? express()
     this.httpServer = createServer(this.app)
 
     this.app.set('trust proxy', this.httpOptions.trustProxy)

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 # Installation
 
 ```sh
-npm install @zhttp/core @zhttp/errors
+npm install @zhttp/core @zhttp/errors zod
 ```
 
 # Basic usage examples


### PR DESCRIPTION
Allow for express to be started outside of zhttp, this allow people with existing servers to easily migrate without needing to replace the whole thing.

Update the readme to include `zod` packages