### PR TITLE
feat(endpoint): support regex in endpoint parameters

### DIFF
--- a/packages/core/src/util/endpoint.ts
+++ b/packages/core/src/util/endpoint.ts
@@ -21,14 +21,20 @@ const methods = [
 export type Method = (typeof methods)[number]
 
 type ExtractRouteParams<Path extends string> = string extends Path
-  ? Record<string, ZodString>
+? Record<string, ZodString>
+: // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  Path extends `${infer _Start}:${infer Param}(${string})/${infer Rest}`
+  ? { [K in Param | keyof ExtractRouteParams<Rest>]: ZodString }
   : // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  Path extends `${infer _Start}:${infer Param}/${infer Rest}`
-    ? { [K in Param | keyof ExtractRouteParams<Rest>]?: ZodString }
+    Path extends `${infer _Start}:${infer Param}/${infer Rest}`
+    ? { [K in Param | keyof ExtractRouteParams<Rest>]: ZodString }
     : // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    Path extends `${infer _Start}:${infer Param}`
+      Path extends `${infer _Start}:${infer Param}(${string})`
       ? { [K in Param]: ZodString }
-      : ZodRawShape
+      : // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        Path extends `${infer _Start}:${infer Param}`
+        ? { [K in Param]: ZodString }
+        : ZodRawShape;
 
 export type InputValidationSchema<Path extends string> = ZodObject<{
   params?: ZodObject<ExtractRouteParams<Path>>


### PR DESCRIPTION
Currently, regular expressions are not supported in the path of endpoints in zhttp. 

Example:
```
controller.endpoint(
  get('/:code([a-Z]{3})')
    .input(
      z.object({
        params: z.object({
          code: z.string(),
        }),
      }),
    )
    .handler(async ({ params: { code } }, req, res) => {
    }),
);
```

Will throw a typing error:

```
Argument of type 'ZodObject<{ params: ZodObject<{ code: ZodString; }, "strip", ZodTypeAny, { code: string; }, { code: string; }>; }, "strip", ZodTypeAny, { ...; }, { ...; }>' is not assignable to parameter of type 'InputValidationSchema<"/:code([a-Z]{3})">'.
  Type '{ params: z.ZodObject<{ code: z.ZodString; }, "strip", z.ZodTypeAny, { code: string; }, { code: string; }>; }' is not assignable to type '{ params?: ZodObject<{ "code([a-Z]{3})": ZodString; }, UnknownKeysParam, ZodTypeAny, { "code([a-Z]{3})": string; }, { ...; }> | undefined; query?: ZodObject<...> | undefined; body?: ZodType<...> | undefined; }'.
    Types of property 'params' are incompatible.
      Type 'ZodObject<{ code: ZodString; }, "strip", ZodTypeAny, { code: string; }, { code: string; }>' is not assignable to type 'ZodObject<{ "code([a-Z]{3})": ZodString; }, UnknownKeysParam, ZodTypeAny, { "code([a-Z]{3})": string; }, { ...; }>'.
        Property '"code([a-Z]{3})"' is missing in type '{ code: z.ZodString; }' but required in type '{ "code([a-Z]{3})": ZodString; }'.
``` 